### PR TITLE
Patch related to the autoloading and ruby

### DIFF
--- a/lib/logstash/inputs/cloudwatch/patch.rb
+++ b/lib/logstash/inputs/cloudwatch/patch.rb
@@ -1,0 +1,20 @@
+# This is patch related to the autoloading and ruby
+#
+# The fix exist in jruby 9k but not in the current jruby, not sure when or it will be backported
+# https://github.com/jruby/jruby/issues/3645
+#
+# AWS is doing tricky name discovery in the module to generate the correct error class and
+# this strategy is bogus in jruby and `eager_autoload` don't fix this issue.
+#
+# This will be a short lived patch since AWS is removing the need.
+# see: https://github.com/aws/aws-sdk-ruby/issues/1301#issuecomment-261115960
+old_stderr = $stderr
+
+$stderr = StringIO.new
+begin
+  module Aws
+    const_set(:CloudWatchLogs, Aws::CloudWatchLogs)
+  end
+ensure
+  $stderr = old_stderr
+end

--- a/lib/logstash/inputs/cloudwatch_logs.rb
+++ b/lib/logstash/inputs/cloudwatch_logs.rb
@@ -7,6 +7,9 @@ require "time"
 require "tmpdir"
 require "stud/interval"
 require "stud/temporary"
+require "logstash/inputs/cloudwatch/patch"
+
+Aws.eager_autoload!
 
 # Stream events from ClougWatch Logs streams.
 #


### PR DESCRIPTION
When I run the plugin on Logstash 5.2.2 I see:

`Aws::Client::Errors isn't found`

I did some exploring and found the S3 plugins had some similar issues.
This was their fix.

```
The fix exist in jruby 9k but not in the current jruby, not sure when or
it will be backported https://github.com/jruby/jruby/issues/3645

AWS is doing tricky name discovery in the module to generate the correct
error class and this strategy is bogus in jruby and `eager_autoload`
don't fix this issue.

This will be a short lived patch since AWS is removing the need.  see:
https://github.com/aws/aws-sdk-ruby/issues/1301#issuecomment-261115960
```