### PR TITLE
Cast date-as-milliseconds string to int to make math possible

### DIFF
--- a/lib/logstash/inputs/cloudwatch_logs.rb
+++ b/lib/logstash/inputs/cloudwatch_logs.rb
@@ -170,7 +170,7 @@ class LogStash::Inputs::CloudWatch_Logs < LogStash::Inputs::Base
             @sincedb[group] = DateTime.now.strftime('%Q')
 
           else
-            @sincedb[group] = DateTime.now.strftime('%Q') - (@start_position * 1000)
+            @sincedb[group] = DateTime.now.strftime('%Q').to_i - (@start_position * 1000)
         end # case @start_position
       end
     end


### PR DESCRIPTION
Before this change I was getting the error ``Error: undefined method `-' for "1506779290686":String`` when trying to use a numeric start_position.
